### PR TITLE
Makes the setup actually install packages :-)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
-from distutils.core import setup
-from distutils.extension import Extension
+from setuptools import setup, Extension, find_packages
 from Cython.Build import cythonize
 import numpy as np
-
 
 ext_modules = [
     Extension(
@@ -50,7 +48,8 @@ setup(
     url='https://github.com/HerculesJack/bayesfast',
     license='Apache License, Version 2.0',
     python_requires=">=3",
-    install_requires=['cython', 'dask', 'distributed', 'numdifftools', 'numpy', 
+    install_requires=['cython', 'dask', 'distributed', 'numdifftools', 'numpy',
                       'scikit-learn', 'scipy'],
+    packages=find_packages(),
     ext_modules=cythonize(ext_modules, language_level="3"),
 )


### PR DESCRIPTION
This PR switches from the old distutils tools to modern setuptools, and adds the `find_packages` magic that was preventing me from installing bayesfast with pip